### PR TITLE
Add missing endpoints for PR #649

### DIFF
--- a/backend/agent-socket-handlers/docker-socket-handler.ts
+++ b/backend/agent-socket-handlers/docker-socket-handler.ts
@@ -239,6 +239,68 @@ export class DockerSocketHandler extends AgentSocketHandler {
             }
         });
 
+        // Start a service
+        agentSocket.on("startService", async (stackName: unknown, serviceName: unknown, callback) => {
+            try {
+                checkLogin(socket);
+
+                if (typeof (stackName) !== "string" || typeof (serviceName) !== "string") {
+                    throw new ValidationError("Stack name and service name must be strings");
+                }
+
+                const stack = await Stack.getStack(server, stackName);
+                await stack.startService(socket, serviceName);
+                stack.joinCombinedTerminal(socket); // Ensure the combined terminal is joined
+                callbackResult({
+                    ok: true,
+                    msg: "Service" + serviceName + " started"
+                }, callback);
+                server.sendStackList();
+            } catch (e) {
+                callbackError(e, callback);
+            }
+        });
+
+        // Stop a service
+        agentSocket.on("stopService", async (stackName: unknown, serviceName: unknown, callback) => {
+            try {
+                checkLogin(socket);
+
+                if (typeof (stackName) !== "string" || typeof (serviceName) !== "string") {
+                    throw new ValidationError("Stack name and service name must be strings");
+                }
+
+                const stack = await Stack.getStack(server, stackName);
+                await stack.stopService(socket, serviceName);
+                callbackResult({
+                    ok: true,
+                    msg: "Service" + serviceName + " stopped"
+                }, callback);
+                server.sendStackList();
+            } catch (e) {
+                callbackError(e, callback);
+            }
+        });
+
+        agentSocket.on("restartService", async (stackName: unknown, serviceName: unknown, callback) => {
+            try {
+                checkLogin(socket);
+
+                if (typeof stackName !== "string" || typeof serviceName !== "string") {
+                    throw new Error("Invalid stackName or serviceName");
+                }
+
+                const stack = await Stack.getStack(server, stackName, true);
+                await stack.restartService(socket, serviceName);
+                callbackResult({
+                    ok: true,
+                    msg: "Service" + serviceName + " restarted"
+                }, callback);
+            } catch (e) {
+                callbackError(e, callback);
+            }
+        });
+
         // Docker stats
         agentSocket.on("dockerStats", async (callback) => {
             try {


### PR DESCRIPTION
When merging in PR #649: Add Container Control Buttons (by https://github.com/mizady), the endpoints to control the services seem to have gone missing. 
As a result, currently the buttons don't work at all.