### PR TITLE
fix(stack): isComposeExitClean raise TypeError when compose is stopped

### DIFF
--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -20,8 +20,6 @@ import {
 import { InteractiveTerminal, Terminal } from "./terminal";
 import childProcessAsync from "promisify-child-process";
 import { Settings } from "./settings";
-import { types } from "sass";
-import List = types.List;
 
 export interface DeleteOptions {
     deleteStackFiles: boolean

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -20,9 +20,28 @@ import {
 import { InteractiveTerminal, Terminal } from "./terminal";
 import childProcessAsync from "promisify-child-process";
 import { Settings } from "./settings";
+import {types} from "sass";
+import List = types.List;
 
 export interface DeleteOptions {
     deleteStackFiles: boolean
+}
+
+interface ComposePSResult {
+    Command: string;
+    CreatedAt: string;
+    ID: string;
+    Image: string;
+    Labels: string;
+    LocalVolumes: string;
+    Mounts: string;
+    Name: string;
+    Networks: string;
+    Project: string;
+    Service: string;
+    Size: string;
+    State: string;
+    Status: string;
 }
 
 export class Stack {
@@ -451,10 +470,13 @@ export class Stack {
         const expectedContainersExited = parseInt(composeStack.Status.split("(")[1].split(")")[0]);
         let cleanlyExitedContainerCount = 0;
 
-        const composeStatus = await this.getSingleComposeStatus(composeStack.Name);
+        let composeStatus = await this.getSingleComposeStatus(composeStack.Name);
 
         if (composeStatus === null) {
             return EXITED;
+        }
+        if (!(typeof composeStatus[Symbol.iterator] === "function")) {
+            composeStatus = [ composeStatus ];
         }
         for (const containerStatus of composeStatus) {
             const status = containerStatus.Status.trim();

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -20,28 +20,11 @@ import {
 import { InteractiveTerminal, Terminal } from "./terminal";
 import childProcessAsync from "promisify-child-process";
 import { Settings } from "./settings";
-import {types} from "sass";
+import { types } from "sass";
 import List = types.List;
 
 export interface DeleteOptions {
     deleteStackFiles: boolean
-}
-
-interface ComposePSResult {
-    Command: string;
-    CreatedAt: string;
-    ID: string;
-    Image: string;
-    Labels: string;
-    LocalVolumes: string;
-    Mounts: string;
-    Name: string;
-    Networks: string;
-    Project: string;
-    Service: string;
-    Size: string;
-    State: string;
-    Status: string;
 }
 
 export class Stack {

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -255,7 +255,7 @@ export class Stack {
 
     async deploy(socket : DockgeSocket) : Promise<number> {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
-        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", ["compose", "up", "-d", "--remove-orphans"], this.path);
+        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "up", "-d", "--remove-orphans" ], this.path);
         if (exitCode !== 0) {
             throw new Error("Failed to deploy, please check the terminal output for more information.");
         }
@@ -264,7 +264,7 @@ export class Stack {
 
     async delete(socket: DockgeSocket, options: DeleteOptions) : Promise<number> {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
-        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", ["compose", "down", "--remove-orphans"], this.path);
+        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "down", "--remove-orphans" ], this.path);
         if (exitCode !== 0) {
             throw new Error(`Failed to delete ${this.name}, please check the terminal output for more information.`);
         }
@@ -282,7 +282,7 @@ export class Stack {
 
     async forceDelete(socket: DockgeSocket): Promise<number> {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
-        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", ["compose", "down", "-v", "--remove-orphans"], this.path);
+        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "down", "-v", "--remove-orphans" ], this.path);
 
         // Remove the stack folder
         await fsAsync.rm(this.path, {
@@ -429,14 +429,14 @@ export class Stack {
         if (!res.stdout) {
             return null;
         }
-        let dockerResponse = res.stdout.toString()
+        let dockerResponse = res.stdout.toString();
         let composeList;
         try {
             composeList = JSON.parse(dockerResponse);
         } catch (error) {
             // Optional: Log the error for debugging purposes
             console.error("Failed to parse JSON from res.stdout: ", res.dockerResponse);
-            return null; 
+            return null;
         }
 
         return composeList;
@@ -448,32 +448,32 @@ export class Stack {
      * Then read all the containers and check if they are exited with status 0 (OK) or something else (Not OK)
      */
     static async isComposeExitClean(composeStack : any[]) : Promise<number> {
-            const expectedContainersExited = parseInt(composeStack.Status.split("(")[1].split(")")[0]);
-            let cleanlyExitedContainerCount = 0;
+        const expectedContainersExited = parseInt(composeStack.Status.split("(")[1].split(")")[0]);
+        let cleanlyExitedContainerCount = 0;
 
-            const composeStatus = await this.getSingleComposeStatus(composeStack.Name);
+        const composeStatus = await this.getSingleComposeStatus(composeStack.Name);
 
-            if (composeStatus === null) {
-                return EXITED;
-            }
-            for (const containerStatus of composeStatus) {
-                const status = containerStatus.Status.trim();
-
-                if (status.startsWith("exited" ,0)) {
-                    if(status.startsWith("exited (0)" ,0)) {
-                        cleanlyExitedContainerCount++;
-                    } else {
-                        return EXITED;
-                    }
-                }
-            }
-
-            if (cleanlyExitedContainerCount == expectedContainersExited) {
-                return RUNNING;
-            }
-            
+        if (composeStatus === null) {
             return EXITED;
         }
+        for (const containerStatus of composeStatus) {
+            const status = containerStatus.Status.trim();
+
+            if (status.startsWith("exited", 0)) {
+                if (status.startsWith("exited (0)", 0)) {
+                    cleanlyExitedContainerCount++;
+                } else {
+                    return EXITED;
+                }
+            }
+        }
+
+        if (cleanlyExitedContainerCount == expectedContainersExited) {
+            return RUNNING;
+        }
+
+        return EXITED;
+    }
 
     /**
      * Convert the status string from `docker compose ls` to the status number
@@ -598,7 +598,7 @@ export class Stack {
         if (exitCode !== 0) {
             throw new Error("Failed to restart, please check the terminal output for more information.");
         }
-        
+
         return exitCode;
     }
 
@@ -680,7 +680,7 @@ export class Stack {
 
     async startService(socket: DockgeSocket, serviceName: string) {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
-        const exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", ["compose", "up", "-d", serviceName], this.path);
+        const exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "up", "-d", serviceName ], this.path);
         if (exitCode !== 0) {
             throw new Error(`Failed to start service ${serviceName}, please check logs for more information.`);
         }
@@ -690,7 +690,7 @@ export class Stack {
 
     async stopService(socket: DockgeSocket, serviceName: string): Promise<number> {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
-        const exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", ["compose", "stop", serviceName], this.path);
+        const exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "stop", serviceName ], this.path);
         if (exitCode !== 0) {
             throw new Error(`Failed to stop service ${serviceName}, please check logs for more information.`);
         }
@@ -700,7 +700,7 @@ export class Stack {
 
     async restartService(socket: DockgeSocket, serviceName: string): Promise<number> {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
-        const exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", ["compose", "restart", serviceName], this.path);
+        const exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "restart", serviceName ], this.path);
         if (exitCode !== 0) {
             throw new Error(`Failed to restart service ${serviceName}, please check logs for more information.`);
         }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

stacks.ts: isComposeExitClean raise TypeError when any compose is stopped

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

<img width="916" height="269" alt="Image" src="https://github.com/user-attachments/assets/f1189778-bb63-443d-bd53-67d36eba4438" />


Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
