### PR TITLE
[FIX] Unable to create compose stack within Dockge

### DIFF
--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -225,6 +225,12 @@ export class Stack {
                 throw new ValidationError("Stack name already exists");
             }
 
+           // If this is a new stack that has no compose file yet, use the stack name as directory
+            if (dir === "") {
+                this._configFilePath = path.join(this.server.stacksDir, this.name);
+                dir = this.path;
+            }
+
             // Create the stack folder
             await fsAsync.mkdir(dir);
         } else {


### PR DESCRIPTION
Handle case for new stack without a compose file by setting directory path.

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

Fixes being unable to create compose stack within Dockge's interface

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)


